### PR TITLE
Fix Next Round during between rounds

### DIFF
--- a/src/components/ClockDisplay.tsx
+++ b/src/components/ClockDisplay.tsx
@@ -169,7 +169,7 @@ const ClockDisplay: React.FC<ClockDisplayProps> = ({
 
           <Button
             onClick={onNextRound}
-            disabled={clockState.currentRound >= clockState.totalRounds || clockState.isBetweenRounds}
+            disabled={clockState.currentRound >= clockState.totalRounds}
             className="h-12 sm:h-16 md:h-20 lg:h-24 bg-gray-400 hover:bg-gray-300 text-black rounded-xl sm:rounded-2xl"
           >
             <SkipForward className="w-5 sm:w-7 md:w-9 lg:w-10 h-5 sm:h-7 md:h-9 lg:h-10" />

--- a/src/components/CountdownClock.tsx
+++ b/src/components/CountdownClock.tsx
@@ -249,8 +249,19 @@ const CountdownClock = () => {
     resetRounds();
   };
 
-  const nextRound = () => {
+  const nextRound = async () => {
     if (clockState.currentRound < clockState.totalRounds) {
+      try {
+        const response = await fetch('/api/next-round', { method: 'POST' });
+        if (response.ok) {
+          addDebugLog('UI', 'Next round via API', {
+            round: clockState.currentRound + 1
+          });
+        }
+      } catch (error) {
+        addDebugLog('UI', 'Failed to advance round', { error: error.message });
+      }
+
       const newRound = clockState.currentRound + 1;
       setClockState(prev => ({
         ...prev,
@@ -263,7 +274,6 @@ const CountdownClock = () => {
         elapsedSeconds: 0,
         isBetweenRounds: false
       }));
-      addDebugLog('UI', 'Next round', { round: newRound });
     }
   };
 


### PR DESCRIPTION
## Summary
- enable Next Round button during between-rounds mode
- call `/api/next-round` when advancing rounds

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6864a7287c30833095e1e19c785eeefc