### PR TITLE
Fix NTP docs and interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ curl http://localhost:8080/api/status
 curl http://localhost:8080/api/ntp-sync
 ```
 
+If the UDP request to the NTP server fails (for example when port 123 is
+blocked), the server automatically falls back to
+`https://worldtimeapi.org/api/ip` to retrieve the current time via HTTPS.
 ### API Docs
 ```bash
 # Open interactive documentation


### PR DESCRIPTION
## Summary
- clarify NTP fallback docs
- default NTP sync every 30 minutes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864a8be338c8330852d8ac79730c332