### PR TITLE
Add NTP disable switch and client URL display

### DIFF
--- a/src/components/CountdownClock.tsx
+++ b/src/components/CountdownClock.tsx
@@ -43,6 +43,7 @@ const CountdownClock = () => {
   const [ntpOffset, setNtpOffset] = useState(0);
   const [ipAddress, setIpAddress] = useState('');
   const [ntpServer, setNtpServer] = useState('time.google.com');
+  const [ntpEnabled, setNtpEnabled] = useState(true);
   const [ntpDrift, setNtpDrift] = useState(0);
   const [lastNtpSync, setLastNtpSync] = useState('');
   const [connectedClients, setConnectedClients] = useState<any[]>([]);
@@ -70,13 +71,14 @@ const CountdownClock = () => {
   };
 
   useEffect(() => {
+    if (!ntpEnabled) return;
     handleSyncWithNTP();
     const ntpInterval = setInterval(
       handleSyncWithNTP,
       DEFAULT_NTP_SYNC_INTERVAL
     );
     return () => clearInterval(ntpInterval);
-  }, [ntpServer, handleSyncWithNTP]);
+  }, [ntpServer, ntpEnabled, handleSyncWithNTP]);
 
   // WebSocket for server communication
   useEffect(() => {
@@ -95,6 +97,7 @@ const CountdownClock = () => {
           // Sync current settings to server
           ws.send(JSON.stringify({
             type: 'sync-settings',
+            url: window.location.href,
             initialTime,
             totalRounds: inputRounds,
             betweenRoundsEnabled,
@@ -460,19 +463,21 @@ const CountdownClock = () => {
             inputRounds={inputRounds}
             betweenRoundsEnabled={betweenRoundsEnabled}
             betweenRoundsTime={betweenRoundsTime}
-            ntpOffset={ntpOffset}
-            ntpServer={ntpServer}
-            lastNtpSync={lastNtpSync}
-            ntpDrift={ntpDrift}
-            setInputMinutes={setInputMinutes}
-            setInputSeconds={setInputSeconds}
-            setInputRounds={setInputRounds}
-            setBetweenRoundsEnabled={setBetweenRoundsEnabled}
-            setBetweenRoundsTime={setBetweenRoundsTime}
-            setNtpServer={setNtpServer}
-            onApplySettings={applySettings}
-            onSyncWithNTP={handleSyncWithNTP}
-          />
+          ntpOffset={ntpOffset}
+          ntpServer={ntpServer}
+          lastNtpSync={lastNtpSync}
+          ntpDrift={ntpDrift}
+          ntpEnabled={ntpEnabled}
+          setInputMinutes={setInputMinutes}
+          setInputSeconds={setInputSeconds}
+          setInputRounds={setInputRounds}
+          setBetweenRoundsEnabled={setBetweenRoundsEnabled}
+          setBetweenRoundsTime={setBetweenRoundsTime}
+          setNtpServer={setNtpServer}
+          setNtpEnabled={setNtpEnabled}
+          onApplySettings={applySettings}
+          onSyncWithNTP={handleSyncWithNTP}
+        />
         </TabsContent>
 
         <TabsContent value="info">

--- a/src/components/DebugTab.tsx
+++ b/src/components/DebugTab.tsx
@@ -53,6 +53,7 @@ const DebugTab: React.FC<DebugTabProps> = ({
                   <div>ID: {client.id || 'Unknown'}</div>
                   <div>Connected: {client.connectedAt ? new Date(client.connectedAt).toLocaleTimeString() : 'Unknown'}</div>
                   <div>IP: {client.ip || 'Unknown'}</div>
+                  <div>URL: {client.url || 'Unknown'}</div>
                 </div>
               </div>
             ))}

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -15,12 +15,14 @@ interface SettingsTabProps {
   ntpServer: string;
   lastNtpSync: string;
   ntpDrift: number;
+  ntpEnabled: boolean;
   setInputMinutes: (value: number) => void;
   setInputSeconds: (value: number) => void;
   setInputRounds: (value: number) => void;
   setBetweenRoundsEnabled: (enabled: boolean) => void;
   setBetweenRoundsTime: (time: number) => void;
   setNtpServer: (server: string) => void;
+  setNtpEnabled: (enabled: boolean) => void;
   onApplySettings: () => void;
   onSyncWithNTP: () => void;
 }
@@ -41,12 +43,14 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   ntpServer,
   lastNtpSync,
   ntpDrift,
+  ntpEnabled,
   setInputMinutes,
   setInputSeconds,
   setInputRounds,
   setBetweenRoundsEnabled,
   setBetweenRoundsTime,
   setNtpServer,
+  setNtpEnabled,
   onApplySettings,
   onSyncWithNTP
 }) => {
@@ -164,12 +168,29 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-6">
+              <div className="flex items-center justify-between">
+                <div className="space-y-2">
+                  <h3 className="text-xl text-white font-semibold">Enable NTP Sync</h3>
+                  <p className="text-gray-300 text-lg">Periodically sync clock with NTP server</p>
+                </div>
+                <Switch
+                  checked={ntpEnabled}
+                  onCheckedChange={setNtpEnabled}
+                  className="scale-150"
+                />
+              </div>
+
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <div className="space-y-4">
                   <div className="flex items-center gap-3">
-                    {ntpOffset !== null ? <Wifi className="w-6 h-6 text-green-400" /> : <WifiOff className="w-6 h-6 text-red-400" />}
+                    {ntpEnabled && ntpOffset !== null ? (
+                      <Wifi className="w-6 h-6 text-green-400" />
+                    ) : (
+                      <WifiOff className="w-6 h-6 text-red-400" />
+                    )}
                     <span className="text-xl text-white">
-                      Status: {ntpOffset !== null ? 'Synchronized' : 'Failed'}
+                      Status:{' '}
+                      {ntpEnabled ? (ntpOffset !== null ? 'Synchronized' : 'Failed') : 'Disabled'}
                     </span>
                   </div>
                   


### PR DESCRIPTION
## Summary
- allow toggling NTP synchronisation
- display URL and IPv4 address of connected clients
- send page URL when clients sync
- normalize IP addresses to IPv4

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc --noEmit` *(fails: command requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_686577204b20833088ccecec17e8cd0f