### PR TITLE
Add Jest tests for NTPSyncManager

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "jest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -81,6 +82,9 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.11"
   }
 }

--- a/tests/ntpSync.test.ts
+++ b/tests/ntpSync.test.ts
@@ -1,0 +1,75 @@
+import { NTPSyncManager } from '../src/utils/ntpSync';
+
+let createSocketMock: any;
+
+jest.mock('dgram', () => ({
+  createSocket: (...args: any[]) => createSocketMock(...args),
+}), { virtual: false });
+
+describe('NTPSyncManager', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('computes offset from UDP response', async () => {
+    createSocketMock = () => {
+      const events: Record<string, any> = {};
+      return {
+        send: jest.fn((buf: Buffer, o: number, l: number, port: number, addr: string, cb: any) => {
+          cb && cb(null);
+          setImmediate(() => {
+            const msg = Buffer.alloc(48);
+            const writeTs = (b: Buffer, off: number, ms: number) => {
+              const sec = Math.floor(ms / 1000) + 2208988800;
+              const frac = Math.floor(((ms % 1000) / 1000) * 2 ** 32);
+              b.writeUInt32BE(sec, off);
+              b.writeUInt32BE(frac, off + 4);
+            };
+            writeTs(msg, 24, 1000); // originate
+            writeTs(msg, 32, 1600); // receive
+            writeTs(msg, 40, 1700); // transmit
+            events['message'](msg);
+          });
+        }),
+        once: jest.fn((ev: string, handler: any) => { events[ev] = handler; }),
+        close: jest.fn(),
+      };
+    };
+
+    const dateSpy = jest.spyOn(Date, 'now');
+    dateSpy.mockReturnValueOnce(1000).mockReturnValueOnce(2000);
+
+    const manager = new NTPSyncManager({ servers: [], syncInterval: 0, driftThreshold: 0, maxRetries: 0 });
+    const result = await (manager as any).queryUdpTime('test');
+    expect(Math.round(result.offset)).toBe(150);
+  });
+
+  test('falls back to HTTP when UDP fails', async () => {
+    createSocketMock = () => {
+      const events: Record<string, any> = {};
+      return {
+        send: jest.fn(() => {
+          events['error'](new Error('fail'));
+        }),
+        once: jest.fn((ev: string, handler: any) => { events[ev] = handler; }),
+        close: jest.fn(),
+      };
+    };
+
+    const dateSpy = jest.spyOn(Date, 'now');
+    dateSpy
+      .mockReturnValueOnce(1000) // udp now
+      .mockReturnValueOnce(3000) // http before
+      .mockReturnValueOnce(3200); // http after
+
+    (global as any).fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve({ utc_datetime: new Date(3400).toISOString() }),
+      })
+    );
+
+    const manager = new NTPSyncManager({ servers: [], syncInterval: 0, driftThreshold: 0, maxRetries: 0 });
+    const result = await manager.syncWithNTP('test');
+    expect(Math.round(result.offset)).toBe(300);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest config and tests for NTPSyncManager
- mock UDP and HTTP responses
- add `npm test` script and required dev dependencies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b5b81cb08330a60b41736d829acb