### PR TITLE
Fix browser NTP sync

### DIFF
--- a/src/components/CountdownClock.tsx
+++ b/src/components/CountdownClock.tsx
@@ -175,6 +175,7 @@ const CountdownClock = () => {
 
   // NTP Sync Management
   useEffect(() => {
+    if (typeof window === 'undefined') return;
     if (ntpSyncEnabled) {
       const config = {
         ...DEFAULT_NTP_CONFIG,


### PR DESCRIPTION
## Summary
- avoid importing `dgram` when bundling for the browser
- fetch `/api/ntp-sync` in the browser for time sync
- guard NTP sync effect when server‑side rendering

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b5b7574083308cdb2899a181f1b2