### PR TITLE
Fix closing brace for updateServerClock

### DIFF
--- a/server.js
+++ b/server.js
@@ -297,13 +297,14 @@ function updateServerClock() {
         serverClockState.elapsedSeconds = elapsedSeconds;
         console.log('Timer completed - all rounds finished');
       }
-    } else {
-      serverClockState.minutes = newMinutes;
-      serverClockState.seconds = adjustedSeconds;
-      serverClockState.elapsedMinutes = elapsedMinutes;
-      serverClockState.elapsedSeconds = elapsedSeconds;
-    }
+  } else {
+    serverClockState.minutes = newMinutes;
+    serverClockState.seconds = adjustedSeconds;
+    serverClockState.elapsedMinutes = elapsedMinutes;
+    serverClockState.elapsedSeconds = elapsedSeconds;
   }
+  }
+}
 }
 
 wss.on('connection', ws => {


### PR DESCRIPTION
## Summary
- fix missing closing brace in `updateServerClock`

## Testing
- `node --check server.js`
- `node server.js` *(fails: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6866b5b712148330a713e930c8bcdd0b