### PR TITLE
Remove unused import in server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,5 +1,4 @@
 import express from 'express';
-import path from 'path';
 import http from 'http';
 import WebSocket, { WebSocketServer } from 'ws';
 import dgram from 'dgram';


### PR DESCRIPTION
## Summary
- drop the unused `path` import from `server.js`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6866b98ca34c8330839b525ab3eb4aff