### PR TITLE
Update NTP settings via sync-settings

### DIFF
--- a/server.js
+++ b/server.js
@@ -350,6 +350,18 @@ wss.on('connection', ws => {
             stopNtpSync();
           }
         }
+        if (typeof data.ntpSyncInterval === 'number') {
+          serverClockState.ntpSyncInterval = data.ntpSyncInterval;
+        }
+        if (typeof data.ntpDriftThreshold === 'number') {
+          serverClockState.ntpDriftThreshold = data.ntpDriftThreshold;
+        }
+        if (
+          typeof data.ntpSyncInterval === 'number' ||
+          typeof data.ntpDriftThreshold === 'number'
+        ) {
+          startNtpSync();
+        }
         if (data.url) {
           const info = connectedClients.get(ws);
           if (info) {

--- a/tests/syncSettingsServer.test.ts
+++ b/tests/syncSettingsServer.test.ts
@@ -1,0 +1,58 @@
+import { spawn, ChildProcessWithoutNullStreams } from 'child_process';
+import WebSocket from 'ws';
+import { once } from 'events';
+
+describe('sync-settings websocket handler', () => {
+  let serverProcess: ChildProcessWithoutNullStreams;
+  const port = 8125;
+
+  beforeAll(async () => {
+    serverProcess = spawn('node', ['server.js'], {
+      env: { ...process.env, PORT: String(port) },
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const onData = (data: Buffer) => {
+        const text = data.toString();
+        if (text.includes('Server listening')) {
+          serverProcess.stdout.off('data', onData);
+          resolve();
+        }
+      };
+      serverProcess.stdout.on('data', onData);
+      serverProcess.stderr.on('data', data => {
+        console.error(data.toString());
+      });
+    });
+  }, 10000);
+
+  afterAll(() => {
+    serverProcess.kill();
+  });
+
+  test('updates NTP config', async () => {
+    const ws = new WebSocket(`ws://localhost:${port}`);
+    await once(ws, 'open');
+
+    ws.send(
+      JSON.stringify({
+        type: 'sync-settings',
+        ntpSyncInterval: 1234,
+        ntpDriftThreshold: 42
+      })
+    );
+
+    await new Promise(res => setTimeout(res, 200));
+
+    const res = await fetch(
+      `http://localhost:${port}/api/status?fields=ntpSyncInterval,ntpDriftThreshold`
+    );
+    const json = await res.json();
+
+    expect(json.ntpSyncInterval).toBe(1234);
+    expect(json.ntpDriftThreshold).toBe(42);
+
+    ws.close();
+  });
+});


### PR DESCRIPTION
## Summary
- allow `sync-settings` websocket messages to update NTP settings
- add regression test showing WebSocket updates ntpSyncInterval and ntpDriftThreshold

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b98b24cc833083888981902c799c