### PR TITLE
Broadcast status after resets

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ curl -X POST http://localhost:8080/api/next-round
 curl -X POST http://localhost:8080/api/previous-round
 ```
 
+All of the above control endpoints immediately broadcast the updated timer
+`status` to any connected WebSocket clients so displays stay in sync.
+
 ### Configuration
 ```bash
 # Set timer duration

--- a/server.js
+++ b/server.js
@@ -449,6 +449,7 @@ app.post('/api/reset', (_req, res) => {
   serverClockState.betweenRoundsSeconds = 0;
   serverClockState.lastUpdateTime = Date.now() + serverClockState.ntpOffset;
   broadcast({ action: 'reset' });
+  broadcast({ type: 'status', ...serverClockState });
   res.json({ success: true });
 });
 
@@ -465,6 +466,7 @@ app.post('/api/reset-time', (_req, res) => {
   serverClockState.currentPauseDuration = 0;
   serverClockState.lastUpdateTime = Date.now() + serverClockState.ntpOffset;
   broadcast({ action: 'reset-time' });
+  broadcast({ type: 'status', ...serverClockState });
   res.json({ success: true });
 });
 
@@ -485,6 +487,7 @@ app.post('/api/reset-rounds', (_req, res) => {
   serverClockState.betweenRoundsSeconds = 0;
   serverClockState.lastUpdateTime = Date.now() + serverClockState.ntpOffset;
   broadcast({ action: 'reset-rounds' });
+  broadcast({ type: 'status', ...serverClockState });
   res.json({ success: true });
 });
 
@@ -507,6 +510,7 @@ app.post('/api/next-round', (_req, res) => {
     serverClockState.lastUpdateTime = Date.now() + serverClockState.ntpOffset;
   }
   broadcast({ action: 'next-round' });
+  broadcast({ type: 'status', ...serverClockState });
   res.json({ success: true });
 });
 
@@ -529,6 +533,7 @@ app.post('/api/previous-round', (_req, res) => {
     serverClockState.lastUpdateTime = Date.now() + serverClockState.ntpOffset;
   }
   broadcast({ action: 'previous-round' });
+  broadcast({ type: 'status', ...serverClockState });
   res.json({ success: true });
 });
 

--- a/tests/statusBroadcastServer.test.ts
+++ b/tests/statusBroadcastServer.test.ts
@@ -1,0 +1,59 @@
+import { spawn, ChildProcessWithoutNullStreams } from 'child_process';
+import WebSocket from 'ws';
+import { once } from 'events';
+
+describe('status broadcast after control actions', () => {
+  let serverProcess: ChildProcessWithoutNullStreams;
+  const port = 8126;
+
+  beforeAll(async () => {
+    serverProcess = spawn('node', ['server.js'], {
+      env: { ...process.env, PORT: String(port) },
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+
+    await new Promise<void>(resolve => {
+      const onData = (data: Buffer) => {
+        if (data.toString().includes('Server listening')) {
+          serverProcess.stdout.off('data', onData);
+          resolve();
+        }
+      };
+      serverProcess.stdout.on('data', onData);
+    });
+  }, 10000);
+
+  afterAll(() => {
+    serverProcess.kill();
+  });
+
+  const cases = [
+    { path: '/api/reset', action: 'reset' },
+    { path: '/api/reset-time', action: 'reset-time' },
+    { path: '/api/reset-rounds', action: 'reset-rounds' },
+    { path: '/api/next-round', action: 'next-round' },
+    { path: '/api/previous-round', action: 'previous-round' }
+  ];
+
+  test.each(cases)('%s triggers status broadcast', async ({ path, action }) => {
+    const ws = new WebSocket(`ws://localhost:${port}`);
+    await once(ws, 'open');
+
+    // flush initial status message
+    await new Promise(res => setTimeout(res, 50));
+    const messages: any[] = [];
+    ws.on('message', msg => messages.push(JSON.parse(msg.toString())));
+
+    await fetch(`http://localhost:${port}${path}`, { method: 'POST' });
+
+    await new Promise(res => setTimeout(res, 200));
+
+    const actionIndex = messages.findIndex(m => m.action === action);
+    const statusAfter = messages.find((m, i) => i > actionIndex && m.type === 'status');
+
+    expect(actionIndex).not.toBe(-1);
+    expect(statusAfter).toBeDefined();
+
+    ws.close();
+  });
+});


### PR DESCRIPTION
## Summary
- broadcast timer status after various control actions
- note automatic status broadcasts in README
- add integration test for status broadcasts

## Testing
- `npm test` *(fails: jest not found)*
- `bun test` *(fails: cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68698af549cc83308ad4960dc09bdebb