### PR TITLE
Fix countdown overshoot

### DIFF
--- a/server.js
+++ b/server.js
@@ -266,7 +266,9 @@ function updateServerClock() {
     const elapsedMinutes = Math.floor(totalElapsed / 60);
     const elapsedSeconds = totalElapsed % 60;
 
-    if (newMinutes < 0) {
+    const countdownFinished = newMinutes < 0 || (newMinutes === 0 && adjustedSeconds === 0);
+
+    if (countdownFinished) {
       if (serverClockState.currentRound < serverClockState.totalRounds) {
         if (serverClockState.betweenRoundsEnabled) {
           // Start between rounds timer


### PR DESCRIPTION
## Summary
- stop the timer as soon as countdown hits `0:00`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869905633d88330b4473d5bd9930c4a