### PR TITLE
Ensure next round resets using timer settings

### DIFF
--- a/src/components/CountdownClock.tsx
+++ b/src/components/CountdownClock.tsx
@@ -327,6 +327,13 @@ const CountdownClock = () => {
   const nextRound = async () => {
     if (clockState.currentRound < clockState.totalRounds) {
       try {
+        // Ensure server initial time matches current timer settings
+        await fetch('/api/set-time', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ minutes: inputMinutes, seconds: inputSeconds })
+        });
+
         const response = await fetch('/api/next-round', { method: 'POST' });
         if (response.ok) {
           addDebugLog('UI', 'Next round via API', {
@@ -338,11 +345,12 @@ const CountdownClock = () => {
       }
 
       const newRound = clockState.currentRound + 1;
+      setInitialTime({ minutes: inputMinutes, seconds: inputSeconds });
       setClockState(prev => ({
         ...prev,
         currentRound: newRound,
-        minutes: initialTime.minutes,
-        seconds: initialTime.seconds,
+        minutes: inputMinutes,
+        seconds: inputSeconds,
         isRunning: false,
         isPaused: false,
         elapsedMinutes: 0,


### PR DESCRIPTION
## Summary
- sync server's initial time with current timer settings before advancing round
- reset client timer for the new round using the settings page values

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68699e471e288330946062eefe41c591