### PR TITLE
Fix for reserved keyword usage in server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -53,9 +53,9 @@ const connectedClients = new Map();
 function getLocalIpAddress() {
   const interfaces = os.networkInterfaces();
   for (const name of Object.keys(interfaces)) {
-    for (const interface of interfaces[name]) {
-      if (interface.family === 'IPv4' && !interface.internal) {
-        return interface.address;
+    for (const iface of interfaces[name]) {
+      if (iface.family === 'IPv4' && !iface.internal) {
+        return iface.address;
       }
     }
   }


### PR DESCRIPTION
## Summary
- use `iface` variable in `getLocalIpAddress` instead of reserved `interface`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d4ab2d2b48330a0a6dc588b1ec1ab